### PR TITLE
add h5py and revise comments regarding MPI

### DIFF
--- a/LABSN_Linux_New_Computer_Setup.bash
+++ b/LABSN_Linux_New_Computer_Setup.bash
@@ -99,8 +99,11 @@ sudo apt-get install libhdf5-7 libhdf5-dev
 ## h5py (python interface to HDF5)  ##
 ## ## ## ## ## ## ## ## ## ## ## ## ##
 ## Standard installation:
-pip install --user h5py
-pip3 install --user h5py
+sudo apt-get install python-h5py
+sudo apt-get install python3-h5py
+## or install throughw pip:
+#pip install --user h5py
+#pip3 install --user h5py
 ## Can also run parallelized, when using an mpi version of HDF5, with
 ## the help of mpi4py:
 # pip install --user mpi4py


### PR DESCRIPTION
@Eric89GXL for now I've just added `h5py` via `pip`. I'm working on a branch that lets users set preferences for installation vehicle (`apt-get`, `pip`, or `git`) and python version (2, 3, or both) at the start, and then installs accordingly.
